### PR TITLE
Potential fix for code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "description": "",
   "dependencies": {
     "axios": "^1.10.0",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^7.5.1"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const axios = require('axios');
 const path = require('path');
+const rateLimit = require('express-rate-limit');
 const app = express();
 
 const PORT = process.env.PORT || 5000;
@@ -123,7 +124,13 @@ app.get('/google/callback', async (req, res) => {
 });
 
 // Default route
-app.get('/', (req, res) => {
+const rootLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+  message: 'Too many requests, please try again later.'
+});
+
+app.get('/', rootLimiter, (req, res) => {
   res.sendFile(path.join(__dirname, 'index.html'));
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/Hoddoc/pdfjpgtool/security/code-scanning/4](https://github.com/Hoddoc/pdfjpgtool/security/code-scanning/4)

To address the issue, we will introduce rate limiting to the application using the `express-rate-limit` package. This middleware will limit the number of requests a client can make to the root endpoint (`/`) within a specified time window. Specifically:

1. Install the `express-rate-limit` package.
2. Configure a rate limiter with appropriate settings (e.g., a maximum of 100 requests per 15 minutes).
3. Apply the rate limiter middleware to the root endpoint (`/`).

This fix ensures that the application is protected against excessive requests to the root endpoint while maintaining its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
